### PR TITLE
Make this work with Ultimaker API v8; logging

### DIFF
--- a/ExampleTool.py
+++ b/ExampleTool.py
@@ -2,11 +2,12 @@
 # This example is released under the terms of the AGPLv3 or higher.
 
 import os.path #To find the QML files.
-from PyQt5.QtCore import pyqtProperty, pyqtSignal, Qt, QUrl, QObject, QVariant #To define a shortcut key and to find the QML files, and to expose information to QML.
-from PyQt5.QtQml import QQmlComponent, QQmlContext #To create a dialogue window.
+from PyQt6.QtCore import pyqtProperty, pyqtSignal, Qt, QUrl, QObject, QVariant #To define a shortcut key and to find the QML files, and to expose information to QML.
+from PyQt6.QtQml import QQmlComponent, QQmlContext #To create a dialogue window.
 
 from UM.Application import Application #To register the information dialogue.
 from UM.Event import Event #To understand what events to react to.
+from UM.Logger import Logger #To improve visibility into what's happening.
 from UM.PluginRegistry import PluginRegistry #To find the QML files in the plug-in folder.
 from UM.Scene.Selection import Selection #To get the current selection and some information about it.
 from UM.Tool import Tool #The PluginObject we're going to extend.
@@ -18,10 +19,15 @@ class ExampleTool(Tool): #The Tool class extends from PluginObject, and we have 
     def __init__(self):
         super().__init__()
 
-        self._shortcut_key = Qt.Key_X
+        self._shortcut_key = Qt.Key.Key_X
 
         #This plug-in creates a window with information about the objects we've selected. That window is lazily-loaded.
         self.info_window = None
+
+        #Log something so we can see if it got this far.
+        #Expect to find the output in cura.log:
+        # https://support.ultimaker.com/s/article/1667337559413
+        Logger.log("d", f'Greetings from {__file__}')
 
     ##  Called when something happens in the scene while our tool is active.
     #
@@ -33,11 +39,13 @@ class ExampleTool(Tool): #The Tool class extends from PluginObject, and we have 
             #As example for this tool, we'll spawn a message with some information.
             if self.info_window is None:
                 self.info_window = self._createDialogue()
+            Logger.log("d", f'Attempting to show dialog')
             self.info_window.show()
 
     ##  Creates a modal dialogue with information about the selection.
     def _createDialogue(self):
         #Create a QML component from the SelectionInfo.qml file.
+        Logger.log("d", f'Attempting to create dialog')
         qml_file_path = os.path.join(PluginRegistry.getInstance().getPluginPath(self.getPluginId()), "SelectionInfo.qml")
         component = Application.getInstance().createQmlComponent(qml_file_path)
 

--- a/SelectionInfo.qml
+++ b/SelectionInfo.qml
@@ -3,7 +3,7 @@
 
 import UM 1.1 as UM //This allows you to use all of Uranium's built-in QML items.
 import QtQuick 2.2 //This allows you to use QtQuick's built-in QML items.
-import QtQuick.Controls 1.1 //Contains the "Label" element.
+import QtQuick.Controls //Contains the "Label" element.
 
 UM.Dialog //Creates a modal window that pops up above the interface.
 {

--- a/plugin.json
+++ b/plugin.json
@@ -2,7 +2,7 @@
     "name": "Example Tool",
     "author": "Ultimaker",
     "version": "1.0",
-    "api": "7.0",
+    "api": "8.0",
     "description": "Example tool to instruct people on how to create Uranium tools.",
     "catalog": "uranium"
 }


### PR DESCRIPTION
Remove version specification on QtQuick.Controls: v1.1 doesn't seem to be in the Cura 8.0 API, so specifying it breaks the plugin. Removing the version specification should make it load the latest. Possibly should do this for the other imports.

Roll the PyQt versions to PyQt6 and change the reference to the Key enum as necessary.

Added logging and left it in because it helped me figure out if I was actually loading the plugin or not, and might be of help to someone else who's just starting out with plugins.